### PR TITLE
Improve README consistency and refactor index screen

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -90,7 +90,7 @@ studia/
 | answer           | TEXT    | 정답 텍스트                             |
 | explanation      | TEXT    | 해설                                    |
 | total_attempts   | INTEGER | 총 시도 횟수                            |
-| correct_attempts | INTEGER | 정답 시도 횟수                          |
+| correct_count | INTEGER | 정답 시도 횟수                          |
 | weight           | REAL    | 문제 가중치 (기본값 1.0)                |
 
 ### `answers` 테이블
@@ -109,7 +109,7 @@ studia/
 
 - 초기값: `1.0`
 - 정답 시: `weight = max(weight - 0.1, 0.1)`
-- 오답 시: `weight = min(weight + 0.1, 10.0)`
+- 오답 시: `weight = weight + 0.3` (최소값 0.1 적용)
 - 가중치가 높을수록 **출제 확률 증가**, 낮을수록 **출제 빈도 감소**
 - 분석 페이지에서 이 가중치를 바탕으로 **학습 우선순위**를 시각화
 

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,17 +1,12 @@
-import { getAllQuestions, initDatabase } from "@/lib/db";
-import { Question } from "@/lib/types";
+import { initDatabase } from "@/lib/db";
 import { useRouter } from "expo-router";
 import { useState } from "react";
 import { Button, Text, View, StyleSheet } from "react-native";
 import { questionFileMap } from "@/lib/questionFileMap";
 import { loadQuestionsFromFile } from "@/lib/loadQuestionsFromFile";
-import * as SQLite from "expo-sqlite";
-
-const db = SQLite.openDatabaseSync("studiaDatabase");
 
 export default function IndexScreen() {
   const router = useRouter();
-  const [questions, setQuestions] = useState<Question[]>([]);
   const [loading, setLoading] = useState(false);
 
   const loadSetAndStart = async (filename: string) => {
@@ -20,8 +15,6 @@ export default function IndexScreen() {
       await initDatabase(); // 데이터베이스 생성
       // await db.runAsync(`DELETE FROM questions`); // 기존 데이터베이스 삭제
       await loadQuestionsFromFile(filename); // QuestionFileMap 파일에서 파일명 읽어오기
-      const loaded = await getAllQuestions();
-      setQuestions(loaded);
       router.push({ pathname: "/two", params: { id: "1" } });
     } catch (e) {
       console.error("문제 세트 로드 실패", e);


### PR DESCRIPTION
## Summary
- clean up the question loader screen
- sync README database docs with the actual schema

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68496269a2c4832d9a6465a8b4b8217d